### PR TITLE
Fix description in reservation details

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -330,7 +330,7 @@
 }
 
 .card-product .card-product-infos {
-  padding: 16px;
+  padding-left: 12px;
 }
 
 .card-reservation-infos {

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -290,7 +290,7 @@
   font-size: 16px;
   font-weight: bold;
   margin: 0;
-  line-height: 2;
+  line-height: 1.5;
 }
 
 .card-reservation p {
@@ -316,7 +316,7 @@
 }
 
 .card-product h2 {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: bold;
   margin: 0;
 }
@@ -326,7 +326,7 @@
   line-height: 1.4;
   opacity: .7;
   margin-bottom: 0;
-  margin-top: 8px;
+  margin-top: 4px;
 }
 
 .card-product .card-product-infos {

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -23,7 +23,7 @@
                 <div class="card-product-infos">
                   <div class="card-reservation-infos">
                     <h2><%= @reservation.planet.name %></h2>
-                    <p><%= @reservation.planet.description %></p>
+                    <p class="mb-2"><%= @reservation.planet.description.split(" ").first(15).join(" ") %>...</p>
                     <span><%= @reviews_avg %><i class="fas fa-star warning"></i> - </span>
                     <span><%= @reservation.planet.reviews.count %> review(s)</span>
                   </div>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -23,7 +23,7 @@
                 <div class="card-product-infos">
                   <div class="card-reservation-infos">
                     <h2><%= @reservation.planet.name %></h2>
-                    <p class="mb-2"><%= @reservation.planet.description.split(" ").first(15).join(" ") %>...</p>
+                    <p class="mb-1"><%= @reservation.planet.description.split(" ").first(10).join(" ") %>...</p>
                     <span><%= @reviews_avg %><i class="fas fa-star warning"></i> - </span>
                     <span><%= @reservation.planet.reviews.count %> review(s)</span>
                   </div>


### PR DESCRIPTION
Before - when a planet's description is long, it hides the planet's name and reviews
Now - only the first 10 words are displayed

![desscription-in-reservarion-form](https://user-images.githubusercontent.com/84081659/155265615-4709beee-347f-4ccb-bea7-6cd6c4818194.png)
![updated-desscription-in-reservarion-form](https://user-images.githubusercontent.com/84081659/155265621-e9b4dac8-d23d-453c-ab2c-8fff33c7248c.png)

